### PR TITLE
Fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Does the following:
 
 Given some hyperparameters, it calculates the ideal re-delivery of electricity to the net, to minimize cost and optimize returns.
 
-Out of the box, the SAJ H2 Home Battery only supports a couple of operating modus. Those are Self-consuming, Time-of-Use, with a schedule. This bot takes into account the selected energy prices (for import and export), predicted weather (using external API) and optimizes the battery levels. It takes into consideration how much is needed at any moment in time and will load when energy prices are negative, sells when the price is optimal. It even leaves some enery in the battery when it's predicted the user need some during the night. Can be self-learning/optimizing.
+Out of the box, the SAJ H2 Home Battery only supports a couple of operating modus. Those are Self-consuming, Time-of-Use, with a schedule. This bot takes into account the selected energy prices (for import and export), predicted weather (using external API) and optimizes the battery levels. It takes into consideration how much is needed at any moment in time and will load when energy prices are negative, sells when the price is optimal. It even leaves some energy in the battery when it's predicted the user need some during the night. Can be self-learning/optimizing.
 
 Main things that are needed to implement:
 - API that reads out and communnicates with H2 (can be based on https://github.com/stanus74/home-assistant-saj-h2-modbus)


### PR DESCRIPTION
## Summary
- fix a typo in the description paragraph of the README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68619e7004f8832e97620a3dcdf83c7c