### PR TITLE
Document Maven proxy usage

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,10 @@
+# Development guidelines
+
+This repository requires a proxy to download Maven dependencies.
+Always run Maven commands with the provided `settings.xml` file:
+
+```bash
+mvn -s settings.xml -DskipTests package
+```
+
+Use four spaces for Java indentation and update the README whenever the build or configuration changes.

--- a/README.md
+++ b/README.md
@@ -12,10 +12,16 @@ All collected sensor data and decisions are stored in a local H2 database so tha
 - Stores data points in an embedded H2 database.
 - Built using Java 17, Maven and Spring Boot.
 
+## Maven proxy settings
+
+Maven requires network access to download dependencies. The included
+`settings.xml` configures a proxy so builds work behind a firewall. Use
+the file with the `-s` flag whenever running Maven.
+
 ## Running locally
 
 ```
-mvn spring-boot:run
+mvn -s settings.xml spring-boot:run
 ```
 
 After startup the REST endpoints will be available on `http://localhost:8080/api`.
@@ -24,7 +30,7 @@ After startup the REST endpoints will be available on `http://localhost:8080/api
 Umbrel allows running Docker based applications. Build the container and deploy it via the Umbrel interface:
 
 ```
-mvn package
+mvn -s settings.xml package
 docker build -t sajbot .
 docker run -p 8080:8080 sajbot
 ```

--- a/settings.xml
+++ b/settings.xml
@@ -1,0 +1,12 @@
+<settings xmlns="http://maven.apache.org/SETTINGS/1.2.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.2.0 https://maven.apache.org/xsd/settings-1.2.0.xsd">
+  <proxies>
+    <proxy>
+      <id>codexProxy</id>
+      <active>true</active>
+      <protocol>http</protocol>
+      <host>proxy</host>
+      <port>8080</port>
+    </proxy>
+  </proxies>
+</settings>


### PR DESCRIPTION
## Summary
- document how to run Maven with the provided settings file
- add AGENTS file with development guidelines

## Testing
- `mvn -s settings.xml -DskipTests package`


------
https://chatgpt.com/codex/tasks/task_e_6861a5767774832eb563ed4c3f7b8ec7