### PR TITLE
Add summary endpoint and tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@
 # virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
 hs_err_pid*
 replay_pid*
+
+# Maven build directory
+target/

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Using weather forecasts and electricity prices the bot decides when the battery 
 All collected sensor data and decisions are stored in a local H2 database so that the algorithm can be tuned in the future.
 
 ## Features
-- REST API that exposes the current battery level and collected data.
+- REST API that exposes the current battery level, collected data and a summary endpoint.
 - Reads a weather API based on the location configured in `application.yml`.
 - Reads electricity prices from a configurable endpoint.
 - Simple "brain" that periodically evaluates the situation and charges/discharges the battery.
@@ -22,6 +22,12 @@ the file with the `-s` flag whenever running Maven.
 
 ```
 mvn spring-boot:run
+```
+
+### Running tests
+
+```
+mvn -s settings.xml test
 ```
 
 After startup the REST endpoints will be available on `http://localhost:8080/api`.

--- a/pom.xml
+++ b/pom.xml
@@ -42,6 +42,12 @@
             <artifactId>j2mod</artifactId>
             <version>3.2.1</version>
         </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <version>${spring.boot.version}</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/src/main/java/com/example/sajbot/controller/SajBotController.java
+++ b/src/main/java/com/example/sajbot/controller/SajBotController.java
@@ -5,6 +5,9 @@ import com.example.sajbot.repository.DataPointRepository;
 import com.example.sajbot.service.BatteryService;
 import com.example.sajbot.service.SajInverterService;
 import com.example.sajbot.model.SajRealtimeData;
+import com.example.sajbot.model.Summary;
+import com.example.sajbot.service.PriceService;
+import com.example.sajbot.service.WeatherService;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -17,13 +20,19 @@ public class SajBotController {
     private final BatteryService batteryService;
     private final DataPointRepository repository;
     private final SajInverterService sajInverterService;
+    private final WeatherService weatherService;
+    private final PriceService priceService;
 
     public SajBotController(BatteryService batteryService,
                             DataPointRepository repository,
-                            SajInverterService sajInverterService) {
+                            SajInverterService sajInverterService,
+                            WeatherService weatherService,
+                            PriceService priceService) {
         this.batteryService = batteryService;
         this.repository = repository;
         this.sajInverterService = sajInverterService;
+        this.weatherService = weatherService;
+        this.priceService = priceService;
     }
 
     @GetMapping("/battery")
@@ -39,5 +48,15 @@ public class SajBotController {
     @GetMapping("/inverter/realtime")
     public SajRealtimeData realtime() {
         return sajInverterService.readRealtimeData();
+    }
+
+    @GetMapping("/summary")
+    public Summary summary() {
+        return new Summary(
+                batteryService.getBatteryLevel(),
+                priceService.getCurrentImportPrice(),
+                priceService.getCurrentExportPrice(),
+                weatherService.getPredictedSolar()
+        );
     }
 }

--- a/src/main/java/com/example/sajbot/model/Summary.java
+++ b/src/main/java/com/example/sajbot/model/Summary.java
@@ -1,0 +1,32 @@
+package com.example.sajbot.model;
+
+public class Summary {
+    private final double batteryLevel;
+    private final double importPrice;
+    private final double exportPrice;
+    private final double predictedSolar;
+
+    public Summary(double batteryLevel, double importPrice,
+                   double exportPrice, double predictedSolar) {
+        this.batteryLevel = batteryLevel;
+        this.importPrice = importPrice;
+        this.exportPrice = exportPrice;
+        this.predictedSolar = predictedSolar;
+    }
+
+    public double getBatteryLevel() {
+        return batteryLevel;
+    }
+
+    public double getImportPrice() {
+        return importPrice;
+    }
+
+    public double getExportPrice() {
+        return exportPrice;
+    }
+
+    public double getPredictedSolar() {
+        return predictedSolar;
+    }
+}

--- a/src/test/java/com/example/sajbot/controller/SajBotControllerTest.java
+++ b/src/test/java/com/example/sajbot/controller/SajBotControllerTest.java
@@ -1,0 +1,48 @@
+package com.example.sajbot.controller;
+
+import com.example.sajbot.service.BatteryService;
+import com.example.sajbot.service.PriceService;
+import com.example.sajbot.service.SajInverterService;
+import com.example.sajbot.service.WeatherService;
+import com.example.sajbot.repository.DataPointRepository;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest(SajBotController.class)
+class SajBotControllerTest {
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private BatteryService batteryService;
+    @MockBean
+    private DataPointRepository repository;
+    @MockBean
+    private SajInverterService sajInverterService;
+    @MockBean
+    private WeatherService weatherService;
+    @MockBean
+    private PriceService priceService;
+
+    @Test
+    void summaryCombinesServices() throws Exception {
+        when(batteryService.getBatteryLevel()).thenReturn(70.0);
+        when(priceService.getCurrentImportPrice()).thenReturn(0.11);
+        when(priceService.getCurrentExportPrice()).thenReturn(0.33);
+        when(weatherService.getPredictedSolar()).thenReturn(90.0);
+
+        mockMvc.perform(get("/api/summary"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.batteryLevel").value(70.0))
+                .andExpect(jsonPath("$.importPrice").value(0.11))
+                .andExpect(jsonPath("$.exportPrice").value(0.33))
+                .andExpect(jsonPath("$.predictedSolar").value(90.0));
+    }
+}

--- a/src/test/java/com/example/sajbot/service/BatteryServiceTest.java
+++ b/src/test/java/com/example/sajbot/service/BatteryServiceTest.java
@@ -1,0 +1,15 @@
+package com.example.sajbot.service;
+
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
+
+class BatteryServiceTest {
+    @Test
+    void chargeAndDischargeRespectLimits() {
+        BatteryService service = new BatteryService();
+        service.charge(60);
+        assertEquals(100.0, service.getBatteryLevel());
+        service.discharge(150);
+        assertEquals(0.0, service.getBatteryLevel());
+    }
+}

--- a/src/test/java/com/example/sajbot/service/BrainServiceTest.java
+++ b/src/test/java/com/example/sajbot/service/BrainServiceTest.java
@@ -1,0 +1,27 @@
+package com.example.sajbot.service;
+
+import com.example.sajbot.model.DataPoint;
+import com.example.sajbot.repository.DataPointRepository;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+class BrainServiceTest {
+    @Test
+    void evaluateStoresDataPoint() {
+        WeatherService weather = mock(WeatherService.class);
+        when(weather.getPredictedSolar()).thenReturn(10.0);
+        PriceService prices = mock(PriceService.class);
+        when(prices.getCurrentImportPrice()).thenReturn(0.10);
+        when(prices.getCurrentExportPrice()).thenReturn(0.40);
+        BatteryService battery = new BatteryService();
+        DataPointRepository repo = mock(DataPointRepository.class);
+
+        BrainService brain = new BrainService(weather, prices, battery, repo);
+        brain.evaluate();
+
+        assertTrue(battery.getBatteryLevel() <= 100 && battery.getBatteryLevel() >= 0);
+        verify(repo).save(any(DataPoint.class));
+    }
+}

--- a/src/test/java/com/example/sajbot/service/PriceServiceTest.java
+++ b/src/test/java/com/example/sajbot/service/PriceServiceTest.java
@@ -1,0 +1,32 @@
+package com.example.sajbot.service;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.client.MockRestServiceServer;
+import org.springframework.web.client.RestTemplate;
+
+import static org.junit.jupiter.api.Assertions.*;
+import org.springframework.test.web.client.ExpectedCount;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
+
+class PriceServiceTest {
+    @Test
+    void readsPricesFromApi() throws Exception {
+        RestTemplate template = new RestTemplate();
+        MockRestServiceServer server = MockRestServiceServer.bindTo(template).build();
+        String url = "http://test/prices";
+        server.expect(ExpectedCount.times(2), requestTo(url))
+                .andRespond(withSuccess("{\"importPrice\":0.12,\"exportPrice\":0.34}", MediaType.APPLICATION_JSON));
+
+        PriceService service = new PriceService(url);
+        // inject RestTemplate using reflection for simplicity
+        java.lang.reflect.Field f = PriceService.class.getDeclaredField("restTemplate");
+        f.setAccessible(true);
+        f.set(service, template);
+
+        assertEquals(0.12, service.getCurrentImportPrice(), 1e-6);
+        assertEquals(0.34, service.getCurrentExportPrice(), 1e-6);
+        server.verify();
+    }
+}

--- a/src/test/java/com/example/sajbot/service/WeatherServiceTest.java
+++ b/src/test/java/com/example/sajbot/service/WeatherServiceTest.java
@@ -1,0 +1,30 @@
+package com.example.sajbot.service;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.client.MockRestServiceServer;
+import org.springframework.web.client.RestTemplate;
+
+import static org.junit.jupiter.api.Assertions.*;
+import org.springframework.test.web.client.ExpectedCount;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
+
+class WeatherServiceTest {
+    @Test
+    void predictedSolarUsesCloudCoverage() throws Exception {
+        RestTemplate template = new RestTemplate();
+        MockRestServiceServer server = MockRestServiceServer.bindTo(template).build();
+        String url = "https://api.openweathermap.org/data/2.5/forecast?q=Loc&appid=KEY&units=metric";
+        server.expect(ExpectedCount.once(), requestTo(url))
+                .andRespond(withSuccess("{\"list\":[{\"clouds\":{\"all\":20}}]}", MediaType.APPLICATION_JSON));
+
+        WeatherService service = new WeatherService("KEY", "Loc");
+        java.lang.reflect.Field f = WeatherService.class.getDeclaredField("restTemplate");
+        f.setAccessible(true);
+        f.set(service, template);
+
+        assertEquals(80.0, service.getPredictedSolar(), 1e-6);
+        server.verify();
+    }
+}


### PR DESCRIPTION
## Summary
- provide summary REST endpoint combining prices, forecast and battery level
- implement new `Summary` model
- add controller unit test
- document summary endpoint in README
- ignore Maven `target/` directory

## Testing
- `mvn -s settings.xml test -q`


------
https://chatgpt.com/codex/tasks/task_e_6861abaf8ee8832eb69f2810cc9dab15