### PR TITLE
Add hourly forecasts for weather and prices

### DIFF
--- a/src/main/java/com/example/sajbot/service/PriceService.java
+++ b/src/main/java/com/example/sajbot/service/PriceService.java
@@ -4,6 +4,9 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.RestTemplate;
 
+import java.util.ArrayList;
+import java.util.List;
+
 @Service
 public class PriceService {
     private final RestTemplate restTemplate = new RestTemplate();
@@ -31,5 +34,31 @@ public class PriceService {
             }
         } catch (Exception ignored) {}
         return 0.05; // fallback default
+    }
+
+    public List<Double> getImportPriceForecast() {
+        List<Double> result = new ArrayList<>();
+        try {
+            var node = restTemplate.getForObject(priceUrl, com.fasterxml.jackson.databind.JsonNode.class);
+            if (node != null && node.has("importPrices")) {
+                for (var priceNode : node.get("importPrices")) {
+                    result.add(priceNode.asDouble());
+                }
+            }
+        } catch (Exception ignored) {}
+        return result;
+    }
+
+    public List<Double> getExportPriceForecast() {
+        List<Double> result = new ArrayList<>();
+        try {
+            var node = restTemplate.getForObject(priceUrl, com.fasterxml.jackson.databind.JsonNode.class);
+            if (node != null && node.has("exportPrices")) {
+                for (var priceNode : node.get("exportPrices")) {
+                    result.add(priceNode.asDouble());
+                }
+            }
+        } catch (Exception ignored) {}
+        return result;
     }
 }

--- a/src/main/java/com/example/sajbot/service/WeatherService.java
+++ b/src/main/java/com/example/sajbot/service/WeatherService.java
@@ -4,6 +4,9 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.RestTemplate;
 
+import java.util.ArrayList;
+import java.util.List;
+
 @Service
 public class WeatherService {
 
@@ -29,5 +32,22 @@ public class WeatherService {
         } catch (Exception ignored) {
         }
         return 0;
+    }
+
+    public List<Double> getHourlySolarForecast() {
+        List<Double> result = new ArrayList<>();
+        String url = "https://api.openweathermap.org/data/2.5/forecast?q=" + location + "&appid=" + apiKey + "&units=metric";
+        try {
+            var node = restTemplate.getForObject(url, com.fasterxml.jackson.databind.JsonNode.class);
+            if (node != null) {
+                var list = node.get("list");
+                for (int i = 0; i < 24 && i < list.size(); i++) {
+                    double clouds = list.get(i).get("clouds").get("all").asDouble();
+                    result.add(100 - clouds);
+                }
+            }
+        } catch (Exception ignored) {
+        }
+        return result;
     }
 }

--- a/src/test/java/com/example/sajbot/service/PriceServiceTest.java
+++ b/src/test/java/com/example/sajbot/service/PriceServiceTest.java
@@ -16,8 +16,8 @@ class PriceServiceTest {
         RestTemplate template = new RestTemplate();
         MockRestServiceServer server = MockRestServiceServer.bindTo(template).build();
         String url = "http://test/prices";
-        server.expect(ExpectedCount.times(2), requestTo(url))
-                .andRespond(withSuccess("{\"importPrice\":0.12,\"exportPrice\":0.34}", MediaType.APPLICATION_JSON));
+        server.expect(ExpectedCount.times(4), requestTo(url))
+                .andRespond(withSuccess("{\"importPrice\":0.12,\"exportPrice\":0.34,\"importPrices\":[0.1,0.2],\"exportPrices\":[0.3,0.4]}", MediaType.APPLICATION_JSON));
 
         PriceService service = new PriceService(url);
         // inject RestTemplate using reflection for simplicity
@@ -27,6 +27,8 @@ class PriceServiceTest {
 
         assertEquals(0.12, service.getCurrentImportPrice(), 1e-6);
         assertEquals(0.34, service.getCurrentExportPrice(), 1e-6);
+        assertEquals(java.util.List.of(0.1, 0.2), service.getImportPriceForecast());
+        assertEquals(java.util.List.of(0.3, 0.4), service.getExportPriceForecast());
         server.verify();
     }
 }

--- a/src/test/java/com/example/sajbot/service/WeatherServiceTest.java
+++ b/src/test/java/com/example/sajbot/service/WeatherServiceTest.java
@@ -27,4 +27,21 @@ class WeatherServiceTest {
         assertEquals(80.0, service.getPredictedSolar(), 1e-6);
         server.verify();
     }
+
+    @Test
+    void hourlySolarForecastParsesValues() throws Exception {
+        RestTemplate template = new RestTemplate();
+        MockRestServiceServer server = MockRestServiceServer.bindTo(template).build();
+        String url = "https://api.openweathermap.org/data/2.5/forecast?q=Loc&appid=KEY&units=metric";
+        server.expect(ExpectedCount.once(), requestTo(url))
+                .andRespond(withSuccess("{\"list\":[{\"clouds\":{\"all\":10}},{\"clouds\":{\"all\":20}}]}", MediaType.APPLICATION_JSON));
+
+        WeatherService service = new WeatherService("KEY", "Loc");
+        java.lang.reflect.Field f = WeatherService.class.getDeclaredField("restTemplate");
+        f.setAccessible(true);
+        f.set(service, template);
+
+        assertEquals(java.util.List.of(90.0, 80.0), service.getHourlySolarForecast());
+        server.verify();
+    }
 }


### PR DESCRIPTION
## Summary
- add hourly solar forecast method in `WeatherService`
- extend `PriceService` with import/export hourly forecasts
- cover new methods with unit tests

## Testing
- `mvn -s settings.xml test`

------
https://chatgpt.com/codex/tasks/task_e_6861b15d1538832eb89827a7873e1869